### PR TITLE
Update head.html to use cache-busting for CSS styling

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -27,7 +27,9 @@
     {% elsif site.icon != blank %}
     <link rel="shortcut icon" href="{{ site.icon | prepend: '/assets/img/' | relative_url}}"/>
     {% endif %}
-    <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
+
+    {% assign cacheBust = site.time | date:'?v=%s' %}
+    <link rel="stylesheet" href="{{ "/assets/css/main.css" | relative_url | append: cacheBust }}">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
 
     <!-- Dark Mode -->


### PR DESCRIPTION
Updated to address issue https://github.com/alshedivat/al-folio/issues/1395.

Implemented a cache-busting feature which refreshes the CSS url using a uniquely generated timestamp made when a new build occurs. This forces browsers to download/reference the updated styling.